### PR TITLE
fix curl argument to force binary output to stdout

### DIFF
--- a/twittering-mode.el
+++ b/twittering-mode.el
@@ -2480,6 +2480,7 @@ The method to perform the request is determined from
 	    ("Expect" . "")))
 	 (curl-args
 	  `("--include" "--silent" "--compressed"
+	    "--output" "-"
 	    ,@(when use-http2 `("--http2"))
 	    ,@(apply 'append
 		     (mapcar


### PR DESCRIPTION
* twittering-mode.el: fix curl argument to force binary output to stdout
Force curl output to stdout since curl version 7.55.0 and later
refuses to output binary data to stdout unless specified explicitly.